### PR TITLE
Set hostname to that of the host machine

### DIFF
--- a/scripts/aliases-set
+++ b/scripts/aliases-set
@@ -69,7 +69,7 @@ function _bx-aliases-set()
 
   local BX_VERSION=${2}
   
-  local CMD=$(printf "docker run --rm -v \$PWD:/build -v \$IAR_LMS_SETTINGS_DIR:/.lms iarsystems/bx${1,,}:${BX_VERSION}")
+  local CMD=$(printf "docker run --rm -h ${HOSTNAME} -v \$PWD:/build -v \$IAR_LMS_SETTINGS_DIR:/.lms iarsystems/bx${1,,}:${BX_VERSION}")
   # <arch> execs
   local IASMARCH=$(printf "alias iasm${BX_ARCH}='${CMD} iasm${BX_ARCH}'")
   eval ${IASMARCH} 


### PR DESCRIPTION
It seems that the license manager can get confused when the build tools are accessed from different Docker instances with different container IDs (and therefore different hostnames). Without this change like this, I start seeing errors from the license check once more than a handful of containers have been accessing the tools in a short period. After the change, the
issue disappears and I can run commands continuously with no errors.