### PR TITLE
Fix run script for Fedora 35 server

### DIFF
--- a/run
+++ b/run
@@ -42,8 +42,6 @@ function _bx_run_container()
 	                     --hostname `hostname` \
 	                     --tty \
 	                     --volume LMS2:/usr/local/etc/IARSystems \
-	                     --volume /etc/timezone:/etc/timezone:ro \
-                             --volume /etc/localtime:/etc/localtime:ro \
 	                     --volume `pwd`:/build \
 	                     ${1})
 


### PR DESCRIPTION
The new "run" script provided with #11 binds the host's `/etc/timezone` to the container's counterparts.

While this seems to be fine for Debian variants, RedHat variants, such as Fedora 35 works differently and does not have such directory, preventing the container for initiating:
```
[sharpgeek@fedora bx-docker]$ ./run iarsystems/bxarm:9.10.2
-- Running a Docker container for bxarm-9.10.2...
docker: Error response from daemon: failed to create shim: OCI runtime create failed: container_linux.go:380: starting container process caused: process_linux.go:545: container init caused: rootfs_linux.go:75: mounting "/etc/timezone" to rootfs at "/etc/timezone" caused: mount through procfd: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type.
-- The working directory is /home/sharpgeek/bx-docker.

-- Now source the aliases-set script:
. /home/sharpgeek/bx-docker/aliases-set 5bb10a45323f343a97bbd9f12caf032a1e67b4ee488fa8c2553dcf8044d938f9
```

Removal of the lines in which "timezone" and "localtime" are bind mounted fix this issue.