### PR TITLE
Fix: bx*.deb only after sudo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ COPY bx*.deb /tmp
 #  libxml2, tzdata           : required by C-STAT
 #
 RUN  apt-get update && \
-     apt-get install -y sudo libsqlite3-0 libxml2 tzdata /tmp/bx*.deb && \
+     apt-get install -y sudo libsqlite3-0 libxml2 tzdata && \
+     apt-get install -y /tmp/bx*.deb && \
      apt-get clean autoclean autoremove && \
      rm -rf /var/lib/apt/lists/* /tmp/*.deb
 


### PR DESCRIPTION
When installing `sudo` inline with `bx*.deb`, there are some corner cases in which our package gets installed before `sudo` setup is finished.

This happens because some post-installation scripts are using `sudo` for performing system-level changes. However, the package itself does not explicitly mark `sudo` as pre-requisite package.

Future versions of the BX installer packages will have such `sudo` dependency removed [TOOL-336].

Fix #24.